### PR TITLE
fix(sdk): remove broken base64 auto-detect hack from read_bytes/download

### DIFF
--- a/python/hopx_ai/_async_files.py
+++ b/python/hopx_ai/_async_files.py
@@ -92,26 +92,9 @@ class AsyncFiles:
             File contents as bytes
         """
         client = await self._get_client()
-        content = await client.get_raw(
+        return await client.get_raw(
             f"/files/download?path={path}", operation="read binary file", context={"path": path}
         )
-
-        # Handle base64-encoded files written via write_bytes()
-        # The Agent API stores base64-encoded files as text, so /files/download
-        # may return the base64 string as bytes instead of decoded binary data.
-        # We detect and decode base64 content to ensure round-trip compatibility.
-        try:
-            # Check if content is valid base64 and decode it
-            decoded = base64.b64decode(content, validate=True)
-            # Verify by re-encoding: if it matches, this was base64-encoded data
-            if base64.b64encode(decoded) == content:
-                logger.debug(f"Decoded base64 content for {path}")
-                return decoded
-        except Exception:
-            # Not valid base64 or decode failed, return raw content
-            pass
-
-        return content
 
     async def list(self, path: str = "/workspace") -> List[FileInfo]:
         """

--- a/python/hopx_ai/files.py
+++ b/python/hopx_ai/files.py
@@ -117,26 +117,7 @@ class Files:
             timeout=timeout,
         )
 
-        content = response.content
-
-        # Handle base64-encoded files written via write_bytes()
-        # The Agent API stores base64-encoded files as text, so /files/download
-        # may return the base64 string as bytes instead of decoded binary data.
-        # We detect and decode base64 content to ensure round-trip compatibility.
-        import base64
-
-        try:
-            # Check if content is valid base64 and decode it
-            decoded = base64.b64decode(content, validate=True)
-            # Verify by re-encoding: if it matches, this was base64-encoded data
-            if base64.b64encode(decoded) == content:
-                logger.debug(f"Decoded base64 content for {path}")
-                return decoded
-        except Exception:
-            # Not valid base64 or decode failed, return raw content
-            pass
-
-        return content
+        return response.content
 
     def write(
         self, path: str, content: str, mode: str = "0644", *, timeout: Optional[int] = None
@@ -323,27 +304,8 @@ class Files:
             timeout=timeout or 60,  # Default 60s for downloads
         )
 
-        content = response.content
-
-        # Handle base64-encoded files written via write_bytes()
-        # The Agent API stores base64-encoded files as text, so /files/download
-        # may return the base64 string as bytes instead of decoded binary data.
-        # We detect and decode base64 content to ensure round-trip compatibility.
-        import base64
-
-        try:
-            # Check if content is valid base64 and decode it
-            decoded = base64.b64decode(content, validate=True)
-            # Verify by re-encoding: if it matches, this was base64-encoded data
-            if base64.b64encode(decoded) == content:
-                logger.debug(f"Decoded base64 content for {remote_path}")
-                content = decoded
-        except Exception:
-            # Not valid base64 or decode failed, use raw content
-            pass
-
         with open(local_path, "wb") as f:
-            f.write(content)
+            f.write(response.content)
 
     def exists(self, path: str, *, timeout: Optional[int] = None) -> bool:
         """


### PR DESCRIPTION
## Summary

Remove the broken base64 auto-detect workaround from the Python SDK's file reading methods.

## Background

The SDK had a workaround that tried to auto-detect and decode base64 content when reading files. This was meant to handle the bug where vm-agent stored base64 strings instead of decoded binary data.

Now that vm-agent properly decodes base64 on write (`encoding: "base64"`), this hack is no longer needed and actually causes false positives on files that happen to look like valid base64.

**Related PR:** hopx-ai/nodemgr#1

## Changes

- Remove base64 auto-detect from `read_bytes()` in `files.py`
- Remove base64 auto-detect from `download()` in `files.py`
- Remove base64 auto-detect from `read_bytes()` in `_async_files.py`

## Test plan

- [ ] Write binary file via `write_bytes()` and read back via `read_bytes()` - should match
- [ ] Write text file and read back - should work unchanged
- [ ] Files that look like base64 but aren't should not be corrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)